### PR TITLE
Fix misleading error message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install and start your server
 
 ```bash
 $ npm install -g couch-persona
-$ couch-persona --host=http://127.0.0.1:5984 --username=john --password=doe
+$ couch-persona --host=example.com --db=http://127.0.0.1:5984 --username=john --password=doe
 ````
 
 Follow the [Quick Setup instructions](https://developer.mozilla.org/en-US/docs/Mozilla/Persona/Quick_Setup) on the MDN wiki to install the persona client on your site, ensure you use the correct urls to sign in and out (`/persona/sign-in` + `/persona/sign-out`). Here is some example working code:

--- a/couch-persona.js
+++ b/couch-persona.js
@@ -170,7 +170,7 @@ commander
   .parse(process.argv);
 
 if (!commander.host || !commander.db) {
-  console.log('The host argument is required');
+  console.log('The host and db arguments are required');
   commander.help();
   process.exit(1);
 }


### PR DESCRIPTION
The result of
couch-persona --host=http://test.com
was "The host argument is required".
Also fixed the readme.
